### PR TITLE
Set TERM environment variable in shell process.

### DIFF
--- a/DTAppController.m
+++ b/DTAppController.m
@@ -53,6 +53,7 @@ OSStatus DTHotKeyHandler(EventHandlerCallRef nextHandler,EventRef theEvent, void
 	signal(SIGPIPE, SIG_IGN);
 	
 	// Set some environment variables for our child processes
+	setenv("TERM", "xterm-256color", 1);
 	setenv("TERM_PROGRAM", "DTerm", 1);
 	setenv("TERM_PROGRAM_VERSION", [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] cStringUsingEncoding:NSASCIIStringEncoding], 1);
 	


### PR DESCRIPTION
Fixes  #16. Some shells like `fish` require the TERM environment variable to be set to
determine whether a terminal emulator has color support, etc. Since DTerm has
support for colors, set the value to `xterm-256color` for maximum support.

I have not actually been able to get color working correctly from `fish` yet, but this at least silences the warning at the beginning of the prompt and should improve support from other commands that look for `$TERM` in their environment. If I am able to improve color support more I will open another PR. 